### PR TITLE
Multithreaded HEIC conversions + frontend placeholder

### DIFF
--- a/Utils/session.py
+++ b/Utils/session.py
@@ -6,6 +6,7 @@ class Session:
         self.timestamp = datetime.now()
         self.images = []
         self.links = []
+        self.loading_count = 0 # number of conversions
     def add_image(self, image_path):
         self.images.append(image_path)
     def add_link(self, link):

--- a/app.py
+++ b/app.py
@@ -159,7 +159,9 @@ def upload_file():
                     print(f"Converted HEIC to PNG: {filename}")
                     if session_id in sessions:
                         sessions[session_id].add_image(f'{GLOBAL_URL_ROOT}static/images/{filename}')
+                        sessions[session_id].loading_count -= 1
                 thread = Thread(target=task, args=(file_path, filename, sessions))
+                sessions[session_id].loading_count += 1
                 thread.start()
             else:
                 # Otherwise, don't convert
@@ -186,7 +188,10 @@ def get_session_links():
     if not session_id in sessions:
         return make_response('Session not found with provided ID', 404)
 
-    return jsonify(sessions[session_id].images)
+    return jsonify({
+        "images": sessions[session_id].images,
+        "loading_count": sessions[session_id].loading_count
+        })
     return ":)"
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -156,6 +156,10 @@ button {
   box-shadow: 0 2px 40px var(--accent-color);
 }
 
+.file-placeholder {
+  cursor: progress;
+}
+
 .button-container {
   display: flex;
   justify-content: space-between;
@@ -172,6 +176,11 @@ button {
   margin-top: 15px;
 }
 
+.copy-button.disabled {
+  background-color: #666;
+  cursor: progress;
+}
+
 .download-button {
   background-color: #333;
   color: #fff;
@@ -181,6 +190,11 @@ button {
   text-decoration: none;
   white-space: nowrap;
   margin-top: 15px;
+}
+
+.download-button.disabled{
+  background-color: #666;
+  cursor: progress;
 }
 
 /* Styles for the upload page */

--- a/templates/index.html
+++ b/templates/index.html
@@ -131,13 +131,14 @@
           const response = await fetch(`./session_links?session_id=${sessionID}`);
           const responseJSON = await response.json();
           console.log(responseJSON);
-          if (responseJSON.length > 0) {
+          const responseLinks = responseJSON.images;
+          if (responseLinks > 0) {
             const noFilesYetText = document.getElementById('no-files-yet');
             if (noFilesYetText) {
               noFilesYetText.remove();
             }
           }
-          for (const imageURL of responseJSON) {
+          for (const imageURL of responseLinks) {
             if (!currentImages.has(imageURL)) {
               currentImages.add(imageURL);
 
@@ -169,6 +170,41 @@
 
               updateCounter();
               
+            }
+          }
+          // Add/remove placeholders for loading images
+          const currentLoadingElements = document.querySelectorAll('.file-placeholder');
+          if (currentLoadingElements.length < responseJSON.loading_count) {
+            const placeholderInnerHTML = `
+              <img
+                src="/static/assets/loader.gif"
+                class="uploaded-image"
+                alt="Uploaded File"
+              />
+              <div class="button-container">
+                <a href="#" download class="download-button disabled"
+                  >🛬 Download</a
+                >
+                <button
+                  disabled
+                  class="copy-button disabled"
+                >
+                  📋 Copy
+                </button>
+              </div>
+              `;
+            for (let i = 0; i < responseJSON.loading_count - currentLoadingElements.length; i++) {
+              const placeholderElement = document.createElement('div');
+              placeholderElement.classList.add('file-container');
+              placeholderElement.classList.add('file-placeholder');
+              placeholderElement.innerHTML = placeholderInnerHTML;
+
+              document.getElementById('file-grid').
+                appendChild(placeholderElement);
+            }
+          } else if (currentLoadingElements.length > responseJSON.loading_count) {
+            for (let i = 0; i < currentLoadingElements.length - responseJSON.loading_count; i++) {
+              currentLoadingElements[currentLoadingElements.length - 1].remove();
             }
           }
         }, pollingDelay);


### PR DESCRIPTION
I noticed that HEIC conversions make the `/upload` route super slow, which makes it seem like the app is broken. Here's the fix that I implemented:
*  Do the conversion in a separate thread so that the HTTP response can be sent without waiting for the conversion to finish.
*  Add a `loading_count` attribute to the `Session` class to store the number of images that are being converted in that session.
*  Send the `loading_count` value as part of the response for `/session_links`.
*  Make it so that when the frontend pings `/session_links`, it displays n placeholder elements, where `n` = `loading_count`.


Here's a demo:
[Screencast from 2024-04-15 19-55-27.webm](https://github.com/leiDnedyA/qr-image-drop/assets/17731136/6ac0e64a-daa1-475e-9921-7afc5aaf71a7)

Note: the window I used for the demo is really small so the image looks huge, but on normal browser sizes it's the same as the other images.